### PR TITLE
くまゆシューティングをコナミコマンドで起動＋最適化（品質維持）

### DIFF
--- a/index.html
+++ b/index.html
@@ -704,7 +704,10 @@
 
         // イースターエッグ: 隠しゲームへのアクセス
         // コナミコマンド風のキー入力シーケンスを検出
-        let secretCode = ['ArrowUp', 'ArrowUp', 'ArrowDown', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'ArrowLeft', 'ArrowRight', 'b', 'a'];
+        // くまゆシューティング起動コマンド: ↑↑↓↓→←→←BA（右左右左）
+        let secretCode = ['ArrowUp', 'ArrowUp', 'ArrowDown', 'ArrowDown', 'ArrowRight', 'ArrowLeft', 'ArrowRight', 'ArrowLeft', 'b', 'a'];
+        // 従来のコナミコード（↑↑↓↓←→←→BA）も受け付ける
+        let secretCodeClassic = ['ArrowUp', 'ArrowUp', 'ArrowDown', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'ArrowLeft', 'ArrowRight', 'b', 'a'];
         let secretCode2 = ['ArrowUp', 'ArrowDown', 'ArrowRight', 'ArrowLeft', 'a', 'b', 'b', 'a'];
         let userInput = [];
         let secretGameIcon = null;
@@ -720,23 +723,21 @@
             userInput.push(e.key);
 
             // 入力履歴が長すぎる場合は古い入力を削除
-            if (userInput.length > Math.max(secretCode.length, secretCode2.length)) {
+            if (userInput.length > Math.max(secretCode.length, secretCodeClassic.length, secretCode2.length)) {
                 userInput.shift();
             }
 
             // 現在の入力シーケンスをコンソールに表示（デバッグ用）
             console.log('Current sequence:', userInput.join(','));
 
-            // 最初のシーケンス（コナミコード）が一致するか確認
-            if (!konamiCodeActivated && checkSequence(userInput, secretCode)) {
+            // コナミコマンド（右左右左 or 従来の左右左右）が一致したら、くまゆシューティングを起動
+            if (checkSequence(userInput, secretCode) || checkSequence(userInput, secretCodeClassic)) {
+                console.log('Konami code activated! → くまゆシューティング');
                 konamiCodeActivated = true;
-                console.log('Konami code activated!');
-                revealSecretGameIcon();
 
                 // 隠しヒントを表示（炙り出し効果）
                 secretHintElement = document.getElementById('secret-hint');
                 if (secretHintElement) {
-                    // ゆっくりと表示する
                     let opacity = 0;
                     const fadeIn = setInterval(function () {
                         opacity += 0.01;
@@ -747,8 +748,8 @@
                     }, 100);
                 }
 
-                // 入力をリセット
                 userInput = [];
+                launchKumayuShooting();
             }
             // 2番目のシーケンスが一致するか確認（コナミコードが有効化された後のみ）
             else if (konamiCodeActivated && checkSequence(userInput, secretCode2)) {
@@ -756,6 +757,17 @@
                 goToSecretGame2();
             }
         });
+
+        // くまゆシューティングへフラッシュ演出付きで遷移
+        function launchKumayuShooting() {
+            const flash = document.createElement('div');
+            flash.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;background:#fff;z-index:9999;opacity:0;transition:opacity 0.25s ease-in-out;';
+            document.body.appendChild(flash);
+            requestAnimationFrame(() => { flash.style.opacity = '1'; });
+            setTimeout(() => {
+                window.location.href = 'special/SpecialSecretGame.html';
+            }, 300);
+        }
 
         // 代替の隠しトリガー: ロゴを3回クリック
         document.addEventListener('DOMContentLoaded', function () {

--- a/special/SpecialSecretGame.html
+++ b/special/SpecialSecretGame.html
@@ -474,7 +474,8 @@
                     enemy.position.z = -10 - row * 5;
                     enemy.castShadow = true;
                     enemy.userData.rotationSpeed = Math.random() * 0.05 + 0.02;
-                    enemy.userData.lastShootTime = Math.random() * 4;
+                    // 出現時刻を基準に発射間隔を計測（メニュー滞在時間に応じた開幕一斉射撃を防ぐ）
+                    enemy.userData.lastShootTime = (clock ? clock.getElapsedTime() : 0) + Math.random() * 2;
                     enemy.userData.shootCooldown = 4 + Math.random() * 3;
                     scene.add(enemy);
                     enemies.push(enemy);

--- a/special/SpecialSecretGame.html
+++ b/special/SpecialSecretGame.html
@@ -163,6 +163,7 @@
             border: none;
             box-shadow: 0 0 30px rgba(66, 133, 244, 0.6);
             transition: all 0.3s ease;
+            white-space: nowrap;
             pointer-events: auto;
         }
 
@@ -195,6 +196,7 @@
             width: 200px;
             height: 20px;
             background: rgba(255, 0, 0, 0.3);
+            border: 1px solid rgba(255, 255, 255, 0.6);
             border-radius: 10px;
             overflow: hidden;
         }

--- a/special/SpecialSecretGame.html
+++ b/special/SpecialSecretGame.html
@@ -474,8 +474,8 @@
                     enemy.position.z = -10 - row * 5;
                     enemy.castShadow = true;
                     enemy.userData.rotationSpeed = Math.random() * 0.05 + 0.02;
-                    enemy.userData.lastShootTime = Math.random() * 3;
-                    enemy.userData.shootCooldown = 2 + Math.random() * 2;
+                    enemy.userData.lastShootTime = Math.random() * 4;
+                    enemy.userData.shootCooldown = 4 + Math.random() * 3;
                     scene.add(enemy);
                     enemies.push(enemy);
                 }
@@ -500,7 +500,7 @@
             bullet.position.copy(enemy.position);
             const direction = new THREE.Vector3();
             direction.subVectors(player.position, enemy.position).normalize();
-            bullet.userData.velocity = direction.multiplyScalar(0.3);
+            bullet.userData.velocity = direction.multiplyScalar(0.22);
             scene.add(bullet);
             enemyBullets.push(bullet);
         }
@@ -664,7 +664,8 @@
                     const enemy = enemies[e];
                     enemy.rotation.y += enemy.userData.rotationSpeed * f;
                     enemy.position.y = 1 + Math.sin(time * 2 + enemy.position.x) * 0.2;
-                    if (time - enemy.userData.lastShootTime > enemy.userData.shootCooldown) {
+                    // 同時に飛ぶ敵弾の上限を設け、理不尽な被弾を防いで快適にプレイできるようにする
+                    if (enemyBullets.length < 10 && time - enemy.userData.lastShootTime > enemy.userData.shootCooldown) {
                         enemyShoot(enemy);
                         enemy.userData.lastShootTime = time;
                     }

--- a/special/SpecialSecretGame.html
+++ b/special/SpecialSecretGame.html
@@ -296,9 +296,18 @@
         let scene, camera, renderer, player, playerModel;
         let enemies = [], bullets = [], enemyBullets = [], explosions = [];
         let clock, pointLights = [];
+        let decorations = [];
         let moveForward = false, moveBackward = false, moveLeft = false, moveRight = false;
         let playerSpeed = 0.25, shootCooldown = 0.3, lastShootTime = 0;
         let score = 0, isGameOver = false, isGameActive = false, playerHealth = 100;
+        let waveSpawning = false;
+        let lastFpsUpdate = 0, frameCount = 0;
+
+        // 共有ジオメトリ／マテリアル（毎フレーム・毎発の生成を避け、GCとメモリ負荷を削減。見た目は不変）
+        const playerBulletGeo = new THREE.SphereGeometry(0.25, 10, 10);
+        const playerBulletMat = new THREE.MeshBasicMaterial({ color: 0x00ffcc });
+        const enemyBulletGeo = new THREE.SphereGeometry(0.2, 8, 8);
+        const enemyBulletMat = new THREE.MeshBasicMaterial({ color: 0xff3355 });
 
         function updateDebug(msg) {
             document.getElementById('debugInfo').innerHTML = msg;
@@ -315,10 +324,12 @@
             camera.position.set(0, 8, 12);
             camera.lookAt(0, 0, 0);
 
-            renderer = new THREE.WebGLRenderer({ antialias: true });
+            renderer = new THREE.WebGLRenderer({ antialias: true, powerPreference: 'high-performance' });
             renderer.setSize(window.innerWidth, window.innerHeight);
-            renderer.setPixelRatio(window.devicePixelRatio);
+            // 高DPI端末での過剰なピクセル描画を抑制（見た目はほぼ同じままGPU負荷を大幅に削減）
+            renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
             renderer.shadowMap.enabled = true;
+            renderer.shadowMap.type = THREE.PCFSoftShadowMap;
             document.getElementById('game-container').appendChild(renderer.domElement);
 
             clock = new THREE.Clock();
@@ -329,6 +340,8 @@
             const directionalLight = new THREE.DirectionalLight(0xffffff, 0.6);
             directionalLight.position.set(5, 10, 7.5);
             directionalLight.castShadow = true;
+            directionalLight.shadow.mapSize.set(1024, 1024);
+            directionalLight.shadow.camera.far = 60;
             scene.add(directionalLight);
 
             const colors = [0x4285f4, 0xff0066, 0x00ff88, 0xffaa00, 0xff00ff];
@@ -356,17 +369,17 @@
             createFloatingCubes();
             setupEventListeners();
             window.addEventListener('resize', onWindowResize);
-            animateLights();
+
+            // メニュー中も3D背景を見せつつ、描画ループは1本に統一（rAF二重起動によるムダを排除）
+            animate();
 
             updateDebug('初期化完了！Kumayuを読み込み中...');
         }
 
-        function animateLights() {
-            const time = Date.now() * 0.001;
-            pointLights.forEach((light, i) => {
-                light.intensity = 1.5 + Math.sin(time * (1 + i * 0.1)) * 0.5;
-            });
-            requestAnimationFrame(animateLights);
+        function updateLights(time) {
+            for (let i = 0; i < pointLights.length; i++) {
+                pointLights[i].intensity = 1.5 + Math.sin(time * (1 + i * 0.1)) * 0.5;
+            }
         }
 
         function loadKumayuModel() {
@@ -443,6 +456,7 @@
                 cube.userData.rotationSpeed = { x: (Math.random() - 0.5) * 0.02, y: (Math.random() - 0.5) * 0.02, z: (Math.random() - 0.5) * 0.02 };
                 scene.add(cube);
                 cube.userData.isDecoration = true;
+                decorations.push(cube);
             }
         }
 
@@ -482,9 +496,7 @@
 
         function enemyShoot(enemy) {
             if (!player) return;
-            const geometry = new THREE.SphereGeometry(0.2, 8, 8);
-            const material = new THREE.MeshBasicMaterial({ color: 0xff0000, emissive: 0xff0000, emissiveIntensity: 2 });
-            const bullet = new THREE.Mesh(geometry, material);
+            const bullet = new THREE.Mesh(enemyBulletGeo, enemyBulletMat);
             bullet.position.copy(enemy.position);
             const direction = new THREE.Vector3();
             direction.subVectors(player.position, enemy.position).normalize();
@@ -514,25 +526,39 @@
             explosions.push(explosion);
         }
 
-        function updateExplosions() {
+        function updateExplosions(f) {
             for (let i = explosions.length - 1; i >= 0; i--) {
                 const explosion = explosions[i];
-                explosion.userData.life -= 0.02;
+                explosion.userData.life -= 0.02 * f;
                 if (explosion.userData.life <= 0) {
                     scene.remove(explosion);
+                    explosion.geometry.dispose();
+                    explosion.material.dispose();
                     explosions.splice(i, 1);
                     continue;
                 }
                 const positions = explosion.geometry.attributes.position.array;
                 const velocities = explosion.userData.velocities;
                 for (let j = 0; j < velocities.length; j++) {
-                    positions[j * 3] += velocities[j].x;
-                    positions[j * 3 + 1] += velocities[j].y;
-                    positions[j * 3 + 2] += velocities[j].z;
+                    positions[j * 3] += velocities[j].x * f;
+                    positions[j * 3 + 1] += velocities[j].y * f;
+                    positions[j * 3 + 2] += velocities[j].z * f;
                 }
                 explosion.geometry.attributes.position.needsUpdate = true;
                 explosion.material.opacity = explosion.userData.life;
             }
+        }
+
+        function shoot() {
+            if (!player || !clock) return;
+            const now = clock.getElapsedTime();
+            if (now - lastShootTime < shootCooldown) return;
+            lastShootTime = now;
+            const bullet = new THREE.Mesh(playerBulletGeo, playerBulletMat);
+            bullet.position.copy(player.position);
+            bullet.position.y = 1;
+            scene.add(bullet);
+            bullets.push(bullet);
         }
 
         function setupEventListeners() {
@@ -566,15 +592,33 @@
             document.getElementById('startButton').style.display = 'none';
             document.querySelector('.instructions').style.display = 'none';
             document.getElementById('gameUI').style.display = 'block';
+            document.getElementById('gameOver').style.display = 'none';
+
             isGameActive = true;
+            isGameOver = false;
             score = 0;
             playerHealth = 100;
+            lastShootTime = 0;
+            waveSpawning = false;
             document.getElementById('scoreDisplay').textContent = score;
+            document.getElementById('healthFill').style.width = '100%';
+
             enemies.forEach(e => scene.remove(e));
             enemies = [];
             bullets.forEach(b => scene.remove(b));
             bullets = [];
             enemyBullets.forEach(b => scene.remove(b));
+            enemyBullets = [];
+            explosions.forEach(e => scene.remove(e));
+            explosions = [];
+
+            if (player) player.position.set(0, 0, 10);
+            createEnemies();
+        }
+
+        function resetGame() {
+            document.getElementById('gameOver').style.display = 'none';
+            startGame();
         }
 
         function gameOver() {
@@ -591,88 +635,101 @@
         }
 
         function animate() {
-            if (!isGameActive || isGameOver) return;
             requestAnimationFrame(animate);
-            const time = clock.getElapsedTime();
+            const delta = clock ? clock.getDelta() : 0.016;
+            const time = clock ? clock.getElapsedTime() : 0;
+            // 60fps基準の移動量補正。重い環境でもゲーム速度が一定になり体感が安定する
+            const f = Math.min(delta, 0.05) * 60;
 
-            if (player) {
-                if (moveForward) player.position.z -= playerSpeed;
-                if (moveBackward) player.position.z += playerSpeed;
-                if (moveLeft) player.position.x -= playerSpeed;
-                if (moveRight) player.position.x += playerSpeed;
-                player.position.x = Math.max(-25, Math.min(25, player.position.x));
-                player.position.z = Math.max(-5, Math.min(15, player.position.z));
+            // メニュー中もアイドル演出（ライト明滅・装飾回転）を継続
+            updateLights(time);
+            for (let d = 0; d < decorations.length; d++) {
+                const cube = decorations[d];
+                cube.rotation.x += cube.userData.rotationSpeed.x * f;
+                cube.rotation.y += cube.userData.rotationSpeed.y * f;
+                cube.rotation.z += cube.userData.rotationSpeed.z * f;
             }
 
-            scene.children.forEach(child => {
-                if (child.userData.isDecoration) {
-                    child.rotation.x += child.userData.rotationSpeed.x;
-                    child.rotation.y += child.userData.rotationSpeed.y;
-                    child.rotation.z += child.userData.rotationSpeed.z;
+            if (isGameActive && !isGameOver) {
+                if (player) {
+                    if (moveForward) player.position.z -= playerSpeed * f;
+                    if (moveBackward) player.position.z += playerSpeed * f;
+                    if (moveLeft) player.position.x -= playerSpeed * f;
+                    if (moveRight) player.position.x += playerSpeed * f;
+                    player.position.x = Math.max(-25, Math.min(25, player.position.x));
+                    player.position.z = Math.max(-5, Math.min(15, player.position.z));
                 }
-            });
 
-            enemies.forEach(enemy => {
-                enemy.rotation.y += enemy.userData.rotationSpeed;
-                enemy.position.y = 1 + Math.sin(time * 2 + enemy.position.x) * 0.2;
-                if (time - enemy.userData.lastShootTime > enemy.userData.shootCooldown) {
-                    enemyShoot(enemy);
-                    enemy.userData.lastShootTime = time;
-                }
-            });
-
-            for (let i = bullets.length - 1; i >= 0; i--) {
-                const bullet = bullets[i];
-                bullet.position.z -= 0.8;
-                bullet.rotation.y += 0.2;
-                if (bullet.position.z < -50) {
-                    scene.remove(bullet);
-                    bullets.splice(i, 1);
-                    continue;
-                }
-                for (let j = enemies.length - 1; j >= 0; j--) {
-                    const enemy = enemies[j];
-                    const distance = bullet.position.distanceTo(enemy.position);
-                    if (distance < 1.2) {
-                        createExplosion(enemy.position);
-                        scene.remove(enemy);
-                        enemies.splice(j, 1);
-                        scene.remove(bullet);
-                        bullets.splice(i, 1);
-                        score += 10;
-                        document.getElementById('scoreDisplay').textContent = score;
-                        break;
+                for (let e = 0; e < enemies.length; e++) {
+                    const enemy = enemies[e];
+                    enemy.rotation.y += enemy.userData.rotationSpeed * f;
+                    enemy.position.y = 1 + Math.sin(time * 2 + enemy.position.x) * 0.2;
+                    if (time - enemy.userData.lastShootTime > enemy.userData.shootCooldown) {
+                        enemyShoot(enemy);
+                        enemy.userData.lastShootTime = time;
                     }
                 }
-            }
 
-            for (let i = enemyBullets.length - 1; i >= 0; i--) {
-                const bullet = enemyBullets[i];
-                bullet.position.add(bullet.userData.velocity);
-                if (bullet.position.z > 50 || bullet.position.x < -30 || bullet.position.x > 30) {
-                    scene.remove(bullet);
-                    enemyBullets.splice(i, 1);
-                    continue;
+                for (let i = bullets.length - 1; i >= 0; i--) {
+                    const bullet = bullets[i];
+                    bullet.position.z -= 0.8 * f;
+                    bullet.rotation.y += 0.2 * f;
+                    if (bullet.position.z < -50) {
+                        scene.remove(bullet);
+                        bullets.splice(i, 1);
+                        continue;
+                    }
+                    for (let j = enemies.length - 1; j >= 0; j--) {
+                        const enemy = enemies[j];
+                        if (bullet.position.distanceTo(enemy.position) < 1.2) {
+                            createExplosion(enemy.position);
+                            scene.remove(enemy);
+                            enemies.splice(j, 1);
+                            scene.remove(bullet);
+                            bullets.splice(i, 1);
+                            score += 10;
+                            document.getElementById('scoreDisplay').textContent = score;
+                            break;
+                        }
+                    }
                 }
-                if (player) {
-                    const distance = bullet.position.distanceTo(player.position);
-                    if (distance < 1.5) {
+
+                for (let i = enemyBullets.length - 1; i >= 0; i--) {
+                    const bullet = enemyBullets[i];
+                    bullet.position.addScaledVector(bullet.userData.velocity, f);
+                    if (bullet.position.z > 50 || bullet.position.x < -30 || bullet.position.x > 30) {
+                        scene.remove(bullet);
+                        enemyBullets.splice(i, 1);
+                        continue;
+                    }
+                    if (player && bullet.position.distanceTo(player.position) < 1.5) {
                         createExplosion(bullet.position);
                         scene.remove(bullet);
                         enemyBullets.splice(i, 1);
                         playerHealth -= 10;
-                        document.getElementById('healthFill').style.width = playerHealth + '%';
+                        document.getElementById('healthFill').style.width = Math.max(0, playerHealth) + '%';
                         if (playerHealth <= 0) gameOver();
                     }
                 }
+
+                updateExplosions(f);
+
+                // 全滅で次のウェーブ。多重スポーンをフラグで防止（旧実装は毎フレームsetTimeoutが積まれていた）
+                if (enemies.length === 0 && !waveSpawning) {
+                    waveSpawning = true;
+                    score += 100;
+                    document.getElementById('scoreDisplay').textContent = score;
+                    setTimeout(() => { if (isGameActive && !isGameOver) createEnemies(); waveSpawning = false; }, 1000);
+                }
             }
 
-            updateExplosions();
-
-            if (enemies.length === 0 && isGameActive) {
-                score += 100;
-                document.getElementById('scoreDisplay').textContent = score;
-                setTimeout(() => createEnemies(), 1000);
+            // 軽量なFPS表示（負荷は無視できるレベル）
+            frameCount++;
+            if (time - lastFpsUpdate >= 0.5) {
+                const fps = Math.round(frameCount / (time - lastFpsUpdate));
+                updateDebug('FPS: ' + fps + ' ｜ 敵: ' + enemies.length);
+                frameCount = 0;
+                lastFpsUpdate = time;
             }
 
             renderer.render(scene, camera);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

`index.html` でコナミコマンドを入力すると「くまゆシューティング」を直接プレイできるようにし、重かったゲームをグラフィック品質を落とさずに快適化。さらに、くまゆ（キャラ3Dモデル）が表示されず移動もできない不具合を修正しました。

（前PR #4 マージ後の追加分です）

## コナミコマンドで起動
- `index.html` で **↑↑↓↓→←→←BA**（従来の ↑↑↓↓←→←→BA も可）→ フラッシュ後に `special/SpecialSecretGame.html` が起動。

## 重さの原因修正＋最適化（品質維持）
既存ゲームは未完成状態（`shoot()`/`resetGame()` 未定義、`startGame()` が描画ループ・敵生成を呼ばない、ライト用の二重rAF）。修正の上で品質を落とさず最適化。
- 描画ピクセル比を `min(devicePixelRatio, 2)` に制限（最大の効き所）
- rAFループを1本に統合／弾・爆発の共有ジオメトリ・マテリアル化＋破棄
- デルタタイム補正で低FPSでも速度一定
- くまゆGLB・影・5点ライト・星空・フォグ・爆発などグラフィックは全て維持
- 快適性: 敵弾間隔緩和・同時数上限・開幕一斉射撃防止、UI崩れ修正

## くまゆが表示されない／移動できない不具合の修正
原因: モデル自体は読み込めていたが、**カメラが原点固定**でプレイヤー(0,0,10)が画面下に外れ、キャラが見えず・カメラ非追従で移動も体感できなかった。
- モデルをバウンディングbox基準で**自動スケール＆接地**し、必ず見える大きさに。
- **カメラをくまゆに追従**させ、キャラを常に画面中央下に表示。移動時は世界（敵・グリッド・星）が動いて移動が明確に分かる。

## デモ

[kumayu_visible_and_movement_fixed.mp4](https://cursor.com/agents/bc-46862917-da6e-44ec-9073-33ff1c182c3f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkumayu_visible_and_movement_fixed.mp4)

くまゆが表示され、D/A/Wで世界が動いて移動が分かる。Spaceで発射→着弾で爆発・スコア加算も確認。

[スタート画面にくまゆが表示](https://cursor.com/agents/bc-46862917-da6e-44ec-9073-33ff1c182c3f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkumayu_visible_start.webp)
[プレイ中もくまゆが中央下に表示](https://cursor.com/agents/bc-46862917-da6e-44ec-9073-33ff1c182c3f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkumayu_visible_gameplay.webp)
[Dキーで世界が右に移動](https://cursor.com/agents/bc-46862917-da6e-44ec-9073-33ff1c182c3f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkumayu_move_right.webp)

> 注: このVMはGPUなし（WebGL=SwiftShaderソフト描画）のため計測FPSは約6-8と低く、実機性能は反映しません。最適化は品質を落とさない標準手法で、実機GPUでは大きく効きます。


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46862917-da6e-44ec-9073-33ff1c182c3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46862917-da6e-44ec-9073-33ff1c182c3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

