### PR TITLE
くまゆが表示されない／移動できない不具合を修正

### DIFF
--- a/special/SpecialSecretGame.html
+++ b/special/SpecialSecretGame.html
@@ -401,8 +401,17 @@
                 function (gltf) {
                     updateDebug('✅ Kumayu読み込み成功！');
                     playerModel = gltf.scene;
-                    playerModel.scale.set(1.0, 1.0, 1.0);
                     playerModel.rotation.y = Math.PI;
+
+                    // GLBの元スケールに依存せず必ず見える大きさに自動調整し、足元を地面(y=0)に接地
+                    let box = new THREE.Box3().setFromObject(playerModel);
+                    const size = new THREE.Vector3();
+                    box.getSize(size);
+                    const targetHeight = 2.6;
+                    const s = size.y > 0.0001 ? targetHeight / size.y : 1;
+                    playerModel.scale.setScalar(s);
+                    box = new THREE.Box3().setFromObject(playerModel);
+                    playerModel.position.y = -box.min.y;
 
                     playerModel.traverse(child => {
                         if (child.isMesh) {
@@ -416,9 +425,10 @@
                     player.position.set(0, 0, 10);
                     scene.add(player);
 
-                    const glowGeometry = new THREE.SphereGeometry(1.5, 16, 16);
-                    const glowMaterial = new THREE.MeshBasicMaterial({ color: 0x00ff88, transparent: true, opacity: 0.2 });
+                    const glowGeometry = new THREE.SphereGeometry(1.6, 16, 16);
+                    const glowMaterial = new THREE.MeshBasicMaterial({ color: 0x00ff88, transparent: true, opacity: 0.25 });
                     const glow = new THREE.Mesh(glowGeometry, glowMaterial);
+                    glow.position.y = 1.2;
                     player.add(glow);
 
                     updateDebug('🐻 Kumayu準備完了！');
@@ -651,6 +661,12 @@
                 cube.rotation.x += cube.userData.rotationSpeed.x * f;
                 cube.rotation.y += cube.userData.rotationSpeed.y * f;
                 cube.rotation.z += cube.userData.rotationSpeed.z * f;
+            }
+
+            // カメラをくまゆに追従させ、キャラを常に画面内に収める（移動が視覚的に分かるようにする）
+            if (player) {
+                camera.position.set(player.position.x, 9, player.position.z + 12);
+                camera.lookAt(player.position.x, 1.2, player.position.z - 12);
             }
 
             if (isGameActive && !isGameOver) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

くまゆシューティング（`special/SpecialSecretGame.html`）で、くまゆ（キャラクターの3Dモデル）が表示されず、移動もできない不具合を修正します。

PR #5 がマージ済みのため、その後に行った本修正を独立したPRとして再提出したものです（差分はこの1コミットのみ）。

## 原因

デバッグ再現の結果、モデル自体は正常に読み込めていました（コンソールに「🐻 Kumayu準備完了！」、`typeof player === "object"`、`THREE.GLTFLoader` は利用可能）。真の原因は次の2点でした。

- **カメラが原点固定**（`(0,8,12)` から原点を注視）で、プレイヤー位置 `(0,0,10)` が画面下端に外れており、くまゆがほぼ画面外だった（緑オーラの一部だけが下端に見える状態）。
- カメラがプレイヤーを追従しないため、移動しても画面が変化せず「動かない」ように見えていた（移動処理自体は動作していた）。

## 修正内容（`special/SpecialSecretGame.html`）

- モデルをバウンディングボックス基準で**自動スケール＆接地**し、GLBの元スケールに依存せず必ず見える大きさに調整。
- **カメラをくまゆに追従**させ、キャラを常に画面中央下に表示。移動時は世界（敵・グリッド・星）が動いて移動が視覚的に分かる。
- グロー（オーラ）の半径・不透明度・位置を微調整。

グラフィック要素（GLBモデル・影・ライト・星空・フォグ・爆発など）はすべて維持しています。

## デモ

[kumayu_visible_and_movement_fixed.mp4](https://cursor.com/agents/bc-46862917-da6e-44ec-9073-33ff1c182c3f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkumayu_visible_and_movement_fixed.mp4)

くまゆが表示され、D/A/W で世界が動いて移動が分かる。Space で発射→着弾で爆発・スコア加算も確認。

[スタート画面にくまゆが表示](https://cursor.com/agents/bc-46862917-da6e-44ec-9073-33ff1c182c3f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkumayu_visible_start.webp)
[プレイ中もくまゆが中央下に表示](https://cursor.com/agents/bc-46862917-da6e-44ec-9073-33ff1c182c3f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkumayu_visible_gameplay.webp)
[Dキーで世界が右に動く（＝右移動）](https://cursor.com/agents/bc-46862917-da6e-44ec-9073-33ff1c182c3f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkumayu_move_right.webp)

> 注: このクラウドVMはGPUなし（WebGL=SwiftShaderソフトウェア描画）のため計測FPSは約6-8と低く、実機性能は反映しません。


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46862917-da6e-44ec-9073-33ff1c182c3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46862917-da6e-44ec-9073-33ff1c182c3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

